### PR TITLE
Add DSQ compatibility export toggle

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -157,6 +157,12 @@ class ExportDTS(bpy.types.Operator, ExportHelper):
     raw_colors = BoolProperty(
         name="Use raw material colors",
         description="Use raw rgb material colors when generating textures",
+        default = False,
+        )
+
+    dsq_compat = BoolProperty(
+        name="Export with DSQ compatibility",
+        description="Use to ensure imported and reexported models work with previously existing DSQ's. Do not enable if you are not reexporting an imported model.",
         default=False,
         )
 


### PR DESCRIPTION
Resolves "Node missing attribute 'index'" errors when trying to export models using imported nodes that are parented to non-imported nodes.